### PR TITLE
[VTO-2893] Add optional "libcxsparse3" package to dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -910,9 +910,10 @@ if (EXPORT_BUILD_DIR)
 
 endif (EXPORT_BUILD_DIR)
 
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libatlas3-base, libc6 (>= 2.14), libcxsparse3.1.4 | libcxsparse3, libgcc1 (>= 1:3.0), libgomp1 (>= 4.9), libgoogle-glog0v5, liblapack3 | liblapack.so.3, libstdc++6 (>= 5.2)")
+
 
 set(CPACK_PACKAGE_VERSION_MAJOR "1")
 set(CPACK_PACKAGE_VERSION_MINOR "13")
 set(CPACK_PACKAGE_VERSION_PATCH "0")
 include(CPack)
-

--- a/run_build.sh
+++ b/run_build.sh
@@ -19,7 +19,6 @@ cmake .. \
 	-DCPACK_PACKAGING_INSTALL_PREFIX="/usr/local" \
 	-DCPACK_GENERATOR="DEB" \
 	-DCPACK_BINARY_DEB="ON" \
-	-DCPACK_DEBIAN_PACKAGE_SHLIBDEPS="ON" \
 	-DCPACK_PACKAGE_CONTACT="eng@ditto.com"
 
 make -j$(nproc) install


### PR DESCRIPTION
On Ubuntu 18.04 and later, the name of "libcxsparse3.1.4" changed to "libcxsparse3", so this package should rely on either one of these packages in order to work on Ubuntu 18.04. Unfortunately this means we have to override the entire dependency list manually (as far as I can divine from the CMake docs and our build process). C'est la vie.

Note that this is a temporary fix until SRE can complete [SRE-734](https://dittovto.atlassian.net/browse/SRE-734), the creation of Nexus repositories for Bionic and Focal packages, in which case we can build a separate package for Ubuntu 18.04 and Ubuntu 20.04.