### PR TITLE
[VTO-3115] Compile ceres for Ubuntu 18.04 and 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -910,10 +910,9 @@ if (EXPORT_BUILD_DIR)
 
 endif (EXPORT_BUILD_DIR)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libatlas3-base, libc6 (>= 2.14), libcxsparse3.1.4 | libcxsparse3, libgcc1 (>= 1:3.0), libgomp1 (>= 4.9), libgoogle-glog0v5, liblapack3 | liblapack.so.3, libstdc++6 (>= 5.2)")
-
 
 set(CPACK_PACKAGE_VERSION_MAJOR "1")
 set(CPACK_PACKAGE_VERSION_MINOR "13")
 set(CPACK_PACKAGE_VERSION_PATCH "0")
 include(CPack)
+

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -1,0 +1,52 @@
+# Recipe of the environment needed to build ar.
+#
+# Author: Frankie Li, Daran He
+FROM ubuntu:bionic
+
+# Standard issued requirements for all build enviornments in Ditto. We need
+# to maintain consistent sets of numerical libraries.
+
+RUN apt-get update -qq && apt-get install -y \
+	build-essential \
+	cmake \
+	git \
+	libgflags-dev \
+	libgtk2.0-dev \
+	pkg-config \
+	wget
+
+RUN apt-get update -qq && apt-get install -y \
+	libblas-dev \
+	libeigen3-dev \
+	libglm-dev \
+	liblapack-dev
+
+RUN apt-get update -qq && apt-get install -y \
+	libtbb2 \
+	libtbb-dev \
+	libjpeg-dev \
+	libpng-dev \
+	libtiff-dev \
+	python-dev \
+	python-numpy
+
+RUN apt-get update -qq && apt-get install -y \
+	libprotobuf-dev \
+	protobuf-compiler
+
+# Ceres dependencies.
+RUN apt-get update -qq && apt-get install -y \
+	libatlas-base-dev \
+	libgoogle-glog-dev \
+	libsuitesparse-dev
+
+# For some reason, libxmu-dev is not included by the latest freeglut3...
+RUN apt-get update -qq && apt-get install -y \
+	freeglut3-dev \
+	libglew-dev \
+	libxmu-dev
+
+# Make build dir for the actual software we want to build.
+ENV BUILD_ROOT=/opt/build
+RUN mkdir ${BUILD_ROOT}
+WORKDIR ${BUILD_ROOT}

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -1,0 +1,55 @@
+# Recipe of the environment needed to build ar.
+#
+# Author: Frankie Li, Daran He
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV TZ              America/Los_Angeles
+
+# Standard issued requirements for all build enviornments in Ditto. We need
+# to maintain consistent sets of numerical libraries.
+
+RUN apt-get update -qq && apt-get install -y \
+	build-essential \
+	cmake \
+	git \
+	libgflags-dev \
+	libgtk2.0-dev \
+	pkg-config \
+	wget
+
+RUN apt-get update -qq && apt-get install -y \
+	libblas-dev \
+	libeigen3-dev \
+	libglm-dev \
+	liblapack-dev
+
+RUN apt-get update -qq && apt-get install -y \
+	libtbb2 \
+	libtbb-dev \
+	libjpeg-dev \
+	libpng-dev \
+	libtiff-dev \
+	python-dev \
+	python-numpy
+
+RUN apt-get update -qq && apt-get install -y \
+	libprotobuf-dev \
+	protobuf-compiler
+
+# Ceres dependencies.
+RUN apt-get update -qq && apt-get install -y \
+	libatlas-base-dev \
+	libgoogle-glog-dev \
+	libsuitesparse-dev
+
+# For some reason, libxmu-dev is not included by the latest freeglut3...
+RUN apt-get update -qq && apt-get install -y \
+	freeglut3-dev \
+	libglew-dev \
+	libxmu-dev
+
+# Make build dir for the actual software we want to build.
+ENV BUILD_ROOT=/opt/build
+RUN mkdir ${BUILD_ROOT}
+WORKDIR ${BUILD_ROOT}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,17 +21,37 @@ properties([[
 def GIT_CREDENTIALS_ID = 'dittovto-buildbot'
 
 def BUILD_CONFIGS = [
+    'ubuntu-20-04' : [
+        'docker_file'   : 'Dockerfile.focal',
+        'apt_prod_repo' : '-',
+        'apt_test_repo' : '-',
+        'dist'          : '-',
+        'nexus_prod'    : 'ditto-focal-release',
+        'nexus_test'    : 'ditto-focal-testing',
+    ],
+    'ubuntu-18-04' : [
+        'docker_file'   : 'Dockerfile.bionic',
+        'apt_prod_repo' : '-',
+        'apt_test_repo' : '-',
+        'dist'          : '-',
+        'nexus_prod'    : 'ditto-bionic-release',
+        'nexus_test'    : 'ditto-bionic-testing',
+    ],
     'ubuntu-16-04' : [
         'docker_file'   : 'Dockerfile.xenial',
         'apt_prod_repo' : '3rdparty-16.04',
         'apt_test_repo' : '3rdparty-16.04-staging',
         'dist'          : 'xenial',
+        'nexus_prod'    : 'ditto-xenial-release',
+        'nexus_test'    : 'ditto-xenial-testing',
     ],
     'ubuntu-14-04' : [
         'docker_file'   : 'Dockerfile.trusty',
         'apt_prod_repo' : '3rdparty-14.04',
         'apt_test_repo' : '3rdparty-14.04-staging',
         'dist'          : 'trusty',
+        'nexus_prod'    : '',
+        'nexus_test'    : '',
     ]
 ]
 
@@ -64,7 +84,8 @@ node('static-minion') {
         ditto_deb.buildInsideDocker(image_name, build_config.docker_file)
         ditto_deb.generatePackageInsideDocker(image_name, version, revision)
         ditto_deb.publishPackageToS3(build_config.apt_test_repo,
-                                     build_config.dist)
+                                     build_config.dist,
+                                     build_config.nexus_test)
       }
 
       stage("Installing from ${platform} repo and test") {
@@ -104,11 +125,19 @@ node('static-minion') {
 
         image_name =
           ditto_utils.buildDockerImageName(git_info.repo_name, platform)
-        apt_repo_to_publish = deploy_mode == "RC" ?
-          build_config.apt_test_repo : build_config.apt_prod_repo
+        if (deploy_mode == "RC") {
+          apt_repo_to_publish = build_config.apt_test_repo
+          nexus_repo_to_publish = build_config.nexus_test
+        } else {
+          apt_repo_to_publish = build_config.apt_prod_repo
+          nexus_repo_to_publish = build_config.nexus_prod
+        }
 
         ditto_deb.generatePackageInsideDocker(image_name, version, revision)
-        ditto_deb.publishPackageToS3(apt_repo_to_publish, build_config.dist)
+        ditto_deb.publishPackageToS3(
+          apt_repo_to_publish,
+          build_config.dist,
+          nexus_repo_to_publish)
       }
     }
 

--- a/run_build.sh
+++ b/run_build.sh
@@ -19,6 +19,7 @@ cmake .. \
 	-DCPACK_PACKAGING_INSTALL_PREFIX="/usr/local" \
 	-DCPACK_GENERATOR="DEB" \
 	-DCPACK_BINARY_DEB="ON" \
+	-DCPACK_DEBIAN_PACKAGE_SHLIBDEPS="ON" \
 	-DCPACK_PACKAGE_CONTACT="eng@ditto.com"
 
 make -j$(nproc) install


### PR DESCRIPTION
Bionic and Focal both have newer patch versions of some packages like libeigen3, so we have to compile ceres specifically for those platforms or there will be installation issues when we try to install ceres in the environment in which we compile AR, which I am also trying to compile in Ubuntu 18.04 and 20.04.

There are no changes in the packaging for Ubuntu 16.04.